### PR TITLE
Consolidate tools to reduce redundancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@ This is a Model Context Protocol (MCP) server for interacting with TimeTagger. I
 
 ## Features
 
-- Query time records within specific timeframes
-- Create new time records
-- Update existing records
-- Hide/delete records
-- Get time summaries by tags
-- Start and stop timers
+- Query time records with flexible filtering options (by time period, tags, etc.)
+- Manage records with a unified interface (create, update, hide, start/stop timers)
+- Analyze time data with various views (summary by tag, daily breakdown, hourly distribution)
 - Manage TimeTagger settings
+- Access server information and updates
 
 ## Claude Desktop Installation
 Add this to your `claude_desktop_config.json`:
@@ -72,18 +70,12 @@ fastmcp install timetagger_mcp.py
 
 ## Available Tools
 
-- `get_records(start_time, end_time)`: Get records within a time range
-- `get_recent_records(hours)`: Get records from the last N hours
-- `get_today_records()`: Get today's records
-- `create_record(description, start_time, end_time)`: Create a new record
-- `update_record(key, description, start_time, end_time)`: Update an existing record
-- `hide_record(key)`: Hide/delete a record
-- `start_timer(description)`: Start a new timer
-- `stop_timer(key)`: Stop an ongoing timer
-- `find_records_by_tag(tag, days)`: Find records with a specific tag
-- `get_time_summary(days)`: Get a summary of time spent on different tags
-- `get_settings()`: Get all TimeTagger settings
-- `update_setting(key, value)`: Update a TimeTagger setting
+- `get_records(start_time, end_time, time_period, tag)`: Get records with flexible filtering options
+- `manage_record(action, description, start_time, end_time, key)`: Create, update, hide, start, or stop records
+- `get_updates_since(since)`: Get records updated since a specific timestamp
+- `get_server_time()`: Get the current server time
+- `manage_settings(action, key, value)`: Get or update TimeTagger settings
+- `analyze_time(analysis_type, time_period, tag)`: Analyze time records with various options
 
 ## Available Resources
 

--- a/timetagger_mcp.py
+++ b/timetagger_mcp.py
@@ -4,6 +4,8 @@ TimeTagger MCP Server
 
 This MCP server provides tools to interact with a TimeTagger instance.
 It allows querying records, updating records, and managing settings.
+
+This version has been streamlined to reduce redundancy in the tools.
 """
 
 import json
@@ -11,7 +13,7 @@ import os
 import time
 import uuid
 from datetime import datetime
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Union
 
 import httpx
 from fastmcp import FastMCP
@@ -129,13 +131,21 @@ def get_updates_resource(since: str) -> str:
 
 
 @mcp.tool()
-def get_records(start_time: int, end_time: int) -> List[TimeRecord]:
+def get_records(
+    start_time: Optional[int] = None, 
+    end_time: Optional[int] = None,
+    time_period: Optional[str] = None,
+    tag: Optional[str] = None
+) -> List[TimeRecord]:
     """
-    Get TimeTagger records within a time range.
+    Get TimeTagger records with flexible filtering options.
 
     Args:
         start_time: Start time as Unix timestamp (t1)
         end_time: End time as Unix timestamp (t2)
+        time_period: Predefined time period - one of "today", "yesterday", "week", "month", "hours:N"
+                    (where N is number of hours to look back)
+        tag: Filter records by tag (with or without # prefix)
 
     Returns:
         List of TimeRecord objects, each containing:
@@ -146,6 +156,50 @@ def get_records(start_time: int, end_time: int) -> List[TimeRecord]:
         - mt: Modified time
         - st: Server time
     """
+    now = int(time.time())
+    
+    # Handle predefined time periods
+    if time_period:
+        if time_period == "today":
+            # Get today's start timestamp (midnight)
+            today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+            start_time = int(today.timestamp())
+            end_time = now
+        elif time_period == "yesterday":
+            # Get yesterday's start and end timestamps
+            today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+            yesterday = today.timestamp() - 86400  # 24 hours in seconds
+            start_time = int(yesterday)
+            end_time = int(today.timestamp())
+        elif time_period == "week":
+            # Get start of week (last 7 days)
+            start_time = now - (7 * 24 * 3600)
+            end_time = now
+        elif time_period == "month":
+            # Get start of month (last 30 days)
+            start_time = now - (30 * 24 * 3600)
+            end_time = now
+        elif time_period.startswith("hours:"):
+            # Get records from the last N hours
+            try:
+                hours = int(time_period.split(":")[1])
+                start_time = now - (hours * 3600)
+                end_time = now
+            except (IndexError, ValueError):
+                raise ValueError("Invalid hours format. Use 'hours:N' where N is a number.")
+    
+    # Default to last 24 hours if no time parameters provided
+    if start_time is None and end_time is None and not time_period:
+        start_time = now - (24 * 3600)  # Default to last 24 hours
+        end_time = now
+    
+    # Ensure both start and end times are set
+    if start_time is None:
+        start_time = 0  # Beginning of time
+    if end_time is None:
+        end_time = now
+    
+    # Get records from the API
     response = httpx.get(
         f"{API_BASE_URL}/records?timerange={start_time}-{end_time}",
         headers=get_headers(),
@@ -153,193 +207,154 @@ def get_records(start_time: int, end_time: int) -> List[TimeRecord]:
 
     if response.status_code == 200:
         data = response.json()
-        return [TimeRecord(**record) for record in data["records"]]
+        records = [TimeRecord(**record) for record in data["records"]]
+        
+        # Filter by tag if specified
+        if tag:
+            # Ensure tag has # prefix
+            if not tag.startswith("#"):
+                tag = f"#{tag}"
+            
+            # Filter records containing the tag
+            records = [record for record in records if tag in record.ds]
+            
+        return records
     else:
         raise Exception(f"Error {response.status_code}: {response.text}")
 
 
 @mcp.tool()
-def get_recent_records(hours: int = 24) -> List[TimeRecord]:
-    """
-    Get TimeTagger records from the last N hours.
-
-    Args:
-        hours: Number of hours to look back
-
-    Returns:
-        List of TimeRecord objects, each containing:
-        - key: Unique identifier for the record
-        - t1: Start time (Unix timestamp) - when the activity began
-        - t2: End time (Unix timestamp) - when the activity ended
-        - ds: Description (including tags with # prefix)
-        - mt: Modified time
-        - st: Server time
-    """
-    now = int(time.time())
-    start_time = now - (hours * 3600)
-
-    return get_records(start_time, now)
-
-
-@mcp.tool()
-def get_today_records() -> List[TimeRecord]:
-    """
-    Get TimeTagger records from today.
-
-    Returns:
-        List of TimeRecord objects, each containing:
-        - key: Unique identifier for the record
-        - t1: Start time (Unix timestamp) - when the activity began
-        - t2: End time (Unix timestamp) - when the activity ended
-        - ds: Description (including tags with # prefix)
-        - mt: Modified time
-        - st: Server time
-    """
-    # Get today's start timestamp (midnight)
-    today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-    start_time = int(today.timestamp())
-    now = int(time.time())
-
-    return get_records(start_time, now)
-
-
-@mcp.tool()
-def create_record(
-    description: str, start_time: int, end_time: Optional[int] = None
-) -> TimeRecord:
-    """
-    Create a new TimeTagger record.
-
-    Args:
-        description: Record description (can include tags with # prefix)
-        start_time: Start time (t1) as Unix timestamp - when the activity began
-        end_time: End time (t2) as Unix timestamp - when the activity ended (None for ongoing records)
-
-    Returns:
-        The created TimeRecord
-    """
-    # Generate a random key
-    record_key = str(uuid.uuid4().hex[:8])
-
-    # Set end_time to the same as start_time if not provided (ongoing record)
-    if end_time is None:
-        end_time = start_time
-
-    # Create the record object
-    record = {
-        "key": record_key,
-        "t1": start_time,
-        "t2": end_time,
-        "ds": description,
-        "mt": int(time.time()),
-        "st": 0.0,  # Server will set this
-    }
-
-    # Send the record to the server
-    response = httpx.put(
-        f"{API_BASE_URL}/records", headers=get_headers(), json=[record]
-    )
-
-    if response.status_code == 200:
-        result = response.json()
-        if record_key in result.get("accepted", []):
-            return TimeRecord(**record)
-        else:
-            errors = result.get("errors", ["Unknown error"])
-            raise Exception(f"Failed to create record: {', '.join(errors)}")
-    else:
-        raise Exception(f"Error {response.status_code}: {response.text}")
-
-
-@mcp.tool()
-def update_record(
-    key: str,
+def manage_record(
+    action: str,
     description: Optional[str] = None,
     start_time: Optional[int] = None,
     end_time: Optional[int] = None,
+    key: Optional[str] = None,
 ) -> TimeRecord:
     """
-    Update an existing TimeTagger record.
+    Create, update, or hide a TimeTagger record.
 
     Args:
-        key: Record unique identifier
-        description: New description (if None, keep existing)
-        start_time: New start time (t1) - when the activity began (if None, keep existing)
-        end_time: New end time (t2) - when the activity ended (if None, keep existing)
+        action: Action to perform - one of "create", "update", "hide", "start", "stop"
+        description: Record description (can include tags with # prefix)
+        start_time: Start time (t1) as Unix timestamp - when the activity began
+        end_time: End time (t2) as Unix timestamp - when the activity ended
+        key: Record unique identifier (required for update, hide, and stop actions)
 
     Returns:
-        The updated TimeRecord
+        The created or updated TimeRecord
     """
-    # First, get the current record to update only specified fields
-    records = get_updates_since(0)
-
-    # Find the record with the matching key
-    current_record = None
-    for record in records:
-        if record.key == key:
-            current_record = record
-            break
-
-    if not current_record:
-        raise Exception(f"Record with key {key} not found")
-
-    # Update only the specified fields
-    updated_record = {
-        "key": key,
-        "t1": start_time if start_time is not None else current_record.t1,
-        "t2": end_time if end_time is not None else current_record.t2,
-        "ds": description if description is not None else current_record.ds,
-        "mt": int(time.time()),
-        "st": 0.0,  # Server will set this
-    }
-
-    # Send the updated record to the server
-    response = httpx.put(
-        f"{API_BASE_URL}/records", headers=get_headers(), json=[updated_record]
-    )
-
-    if response.status_code == 200:
-        result = response.json()
-        if key in result.get("accepted", []):
-            return TimeRecord(**updated_record)
+    now = int(time.time())
+    
+    # Validate action
+    valid_actions = ["create", "update", "hide", "start", "stop"]
+    if action not in valid_actions:
+        raise ValueError(f"Invalid action: {action}. Must be one of {valid_actions}")
+    
+    # Handle different actions
+    if action == "create":
+        if description is None:
+            raise ValueError("Description is required for creating a record")
+        
+        # Set default times if not provided
+        if start_time is None:
+            start_time = now
+        if end_time is None:
+            end_time = start_time  # Ongoing record
+            
+        # Generate a random key
+        record_key = str(uuid.uuid4().hex[:8])
+        
+        # Create the record object
+        record = {
+            "key": record_key,
+            "t1": start_time,
+            "t2": end_time,
+            "ds": description,
+            "mt": now,
+            "st": 0.0,  # Server will set this
+        }
+        
+        # Send the record to the server
+        response = httpx.put(
+            f"{API_BASE_URL}/records", headers=get_headers(), json=[record]
+        )
+        
+        if response.status_code == 200:
+            result = response.json()
+            if record_key in result.get("accepted", []):
+                return TimeRecord(**record)
+            else:
+                errors = result.get("errors", ["Unknown error"])
+                raise Exception(f"Failed to create record: {', '.join(errors)}")
         else:
-            errors = result.get("errors", ["Unknown error"])
-            raise Exception(f"Failed to update record: {', '.join(errors)}")
-    else:
-        raise Exception(f"Error {response.status_code}: {response.text}")
-
-
-@mcp.tool()
-def hide_record(key: str) -> TimeRecord:
-    """
-    Hide a TimeTagger record (marks it as deleted).
-
-    Args:
-        key: Record unique identifier
-
-    Returns:
-        The hidden TimeRecord
-    """
-    # Get the current record
-    records = get_updates_since(0)
-
-    # Find the record with the matching key
-    current_record = None
-    for record in records:
-        if record.key == key:
-            current_record = record
-            break
-
-    if not current_record:
-        raise Exception(f"Record with key {key} not found")
-
-    # By convention, records with description starting with "HIDDEN" are considered deleted
-    description = current_record.ds
-    if not description.startswith("HIDDEN"):
-        description = f"HIDDEN {description}"
-
-    # Update the record with the HIDDEN prefix
-    return update_record(key, description=description)
+            raise Exception(f"Error {response.status_code}: {response.text}")
+            
+    elif action == "start":
+        # Start a timer (create an ongoing record)
+        if description is None:
+            raise ValueError("Description is required for starting a timer")
+            
+        # Create a record with t1 and t2 set to the current time
+        return manage_record("create", description=description, start_time=now, end_time=now)
+        
+    elif action in ["update", "hide", "stop"]:
+        if key is None:
+            raise ValueError(f"Record key is required for {action} action")
+            
+        # Get the current record
+        records = get_updates_since(0)
+        
+        # Find the record with the matching key
+        current_record = None
+        for record in records:
+            if record.key == key:
+                current_record = record
+                break
+                
+        if not current_record:
+            raise Exception(f"Record with key {key} not found")
+            
+        # Prepare the updated record based on the action
+        if action == "hide":
+            # By convention, records with description starting with "HIDDEN" are considered deleted
+            if not current_record.ds.startswith("HIDDEN"):
+                description = f"HIDDEN {current_record.ds}"
+            else:
+                description = current_record.ds
+                
+        elif action == "stop":
+            # Stop a timer by setting the end time to now
+            end_time = now
+            description = current_record.ds
+            
+        # Update only the specified fields
+        updated_record = {
+            "key": key,
+            "t1": start_time if start_time is not None else current_record.t1,
+            "t2": end_time if end_time is not None else current_record.t2,
+            "ds": description if description is not None else current_record.ds,
+            "mt": now,
+            "st": 0.0,  # Server will set this
+        }
+        
+        # Send the updated record to the server
+        response = httpx.put(
+            f"{API_BASE_URL}/records", headers=get_headers(), json=[updated_record]
+        )
+        
+        if response.status_code == 200:
+            result = response.json()
+            if key in result.get("accepted", []):
+                return TimeRecord(**updated_record)
+            else:
+                errors = result.get("errors", ["Unknown error"])
+                raise Exception(f"Failed to update record: {', '.join(errors)}")
+        else:
+            raise Exception(f"Error {response.status_code}: {response.text}")
+    
+    # This should never happen due to the validation above
+    raise ValueError(f"Unhandled action: {action}")
 
 
 @mcp.tool()
@@ -388,163 +403,162 @@ def get_server_time() -> float:
 
 
 @mcp.tool()
-def get_settings() -> List[TimeSetting]:
+def manage_settings(
+    action: str = "get",
+    key: Optional[str] = None,
+    value: Optional[Any] = None
+) -> Union[List[TimeSetting], TimeSetting]:
     """
-    Get all TimeTagger settings.
-
-    Returns:
-        List of TimeSetting objects, each containing:
-        - key: Setting identifier
-        - value: The setting value (can be any JSON-compatible type)
-        - mt: Modified time
-        - st: Server time
-    """
-    response = httpx.get(f"{API_BASE_URL}/settings", headers=get_headers())
-
-    if response.status_code == 200:
-        data = response.json()
-        return [TimeSetting(**setting) for setting in data["settings"]]
-    else:
-        raise Exception(f"Error {response.status_code}: {response.text}")
-
-
-@mcp.tool()
-def update_setting(key: str, value: Any) -> TimeSetting:
-    """
-    Update a TimeTagger setting.
+    Get or update TimeTagger settings.
 
     Args:
-        key: Setting key
-        value: New setting value
+        action: Action to perform - one of "get" or "update"
+        key: Setting key (required for update)
+        value: New setting value (required for update)
 
     Returns:
-        The updated TimeSetting
+        For "get" action: List of TimeSetting objects
+        For "update" action: The updated TimeSetting
     """
-    setting = {
-        "key": key,
-        "value": value,
-        "mt": int(time.time()),
-        "st": 0.0,  # Server will set this
-    }
+    # Validate action
+    valid_actions = ["get", "update"]
+    if action not in valid_actions:
+        raise ValueError(f"Invalid action: {action}. Must be one of {valid_actions}")
+    
+    if action == "get":
+        # Get all settings
+        response = httpx.get(f"{API_BASE_URL}/settings", headers=get_headers())
 
-    response = httpx.put(
-        f"{API_BASE_URL}/settings", headers=get_headers(), json=[setting]
-    )
-
-    if response.status_code == 200:
-        result = response.json()
-        if key in result.get("accepted", []):
-            return TimeSetting(**setting)
+        if response.status_code == 200:
+            data = response.json()
+            return [TimeSetting(**setting) for setting in data["settings"]]
         else:
-            errors = result.get("errors", ["Unknown error"])
-            raise Exception(f"Failed to update setting: {', '.join(errors)}")
-    else:
-        raise Exception(f"Error {response.status_code}: {response.text}")
+            raise Exception(f"Error {response.status_code}: {response.text}")
+            
+    elif action == "update":
+        # Validate parameters
+        if key is None:
+            raise ValueError("Setting key is required for update action")
+        if value is None:
+            raise ValueError("Setting value is required for update action")
+            
+        # Create the setting object
+        setting = {
+            "key": key,
+            "value": value,
+            "mt": int(time.time()),
+            "st": 0.0,  # Server will set this
+        }
 
+        # Send the setting to the server
+        response = httpx.put(
+            f"{API_BASE_URL}/settings", headers=get_headers(), json=[setting]
+        )
 
-@mcp.tool()
-def start_timer(description: str) -> TimeRecord:
-    """
-    Start a new timer (create an ongoing record).
-
-    Args:
-        description: Record description (can include tags with # prefix)
-
-    Returns:
-        The created TimeRecord with t1 and t2 set to the current time
-    """
-    now = int(time.time())
-    return create_record(description, now, now)
-
-
-@mcp.tool()
-def stop_timer(key: str) -> TimeRecord:
-    """
-    Stop an ongoing timer.
-
-    Args:
-        key: Record unique identifier
-
-    Returns:
-        The updated TimeRecord with t2 set to the current time
-    """
-    now = int(time.time())
-    return update_record(key, end_time=now)
-
-
-@mcp.tool()
-def find_records_by_tag(tag: str, days: int = 30) -> List[TimeRecord]:
-    """
-    Find records with a specific tag.
-
-    Args:
-        tag: Tag to search for (without # prefix)
-        days: Number of days to look back
-
-    Returns:
-        List of TimeRecord objects that match the tag, each containing:
-        - key: Unique identifier for the record
-        - t1: Start time (Unix timestamp) - when the activity began
-        - t2: End time (Unix timestamp) - when the activity ended
-        - ds: Description (including tags with # prefix)
-        - mt: Modified time
-        - st: Server time
-    """
-    # Ensure tag has # prefix
-    if not tag.startswith("#"):
-        tag = f"#{tag}"
-
-    # Get records from the last N days
-    now = int(time.time())
-    start_time = now - (days * 24 * 3600)
-
-    records = get_records(start_time, now)
-
-    # Filter records containing the tag
-    return [record for record in records if tag in record.ds]
-
-
-@mcp.tool()
-def get_time_summary(days: int = 7) -> Dict[str, float]:
-    """
-    Get a summary of time spent on different tags.
-
-    Args:
-        days: Number of days to include in the summary
-
-    Returns:
-        Dictionary mapping tags to hours spent
-    """
-    # Get records from the last N days
-    now = int(time.time())
-    start_time = now - (days * 24 * 3600)
-
-    records = get_records(start_time, now)
-
-    # Extract tags from descriptions
-    tag_hours = {}
-
-    for record in records:
-        # Skip hidden/deleted records
-        if record.ds.startswith("HIDDEN"):
-            continue
-
-        # Calculate duration in hours
-        duration = (record.t2 - record.t1) / 3600
-
-        # Extract tags (words starting with #)
-        tags = [word for word in record.ds.split() if word.startswith("#")]
-
-        if not tags:
-            # If no tags, count as "untagged"
-            tag = "untagged"
-            tag_hours[tag] = tag_hours.get(tag, 0) + duration
+        if response.status_code == 200:
+            result = response.json()
+            if key in result.get("accepted", []):
+                return TimeSetting(**setting)
+            else:
+                errors = result.get("errors", ["Unknown error"])
+                raise Exception(f"Failed to update setting: {', '.join(errors)}")
         else:
-            # Add duration to each tag
-            for tag in tags:
-                tag_hours[tag] = tag_hours.get(tag, 0) + duration
+            raise Exception(f"Error {response.status_code}: {response.text}")
+    
+    # This should never happen due to the validation above
+    raise ValueError(f"Unhandled action: {action}")
 
-    return tag_hours
+
+@mcp.tool()
+def analyze_time(
+    analysis_type: str = "summary",
+    time_period: str = "week",
+    tag: Optional[str] = None
+) -> Dict[str, Any]:
+    """
+    Analyze time records with various options.
+
+    Args:
+        analysis_type: Type of analysis - one of "summary", "daily", "hourly"
+        time_period: Time period to analyze - one of "today", "yesterday", "week", "month", "hours:N"
+        tag: Optional tag to filter by
+
+    Returns:
+        Dictionary with analysis results
+    """
+    # Get records for the specified time period
+    records = get_records(time_period=time_period, tag=tag)
+    
+    # Skip hidden/deleted records
+    records = [r for r in records if not r.ds.startswith("HIDDEN")]
+    
+    if analysis_type == "summary":
+        # Extract tags from descriptions
+        tag_hours = {}
+
+        for record in records:
+            # Calculate duration in hours
+            duration = (record.t2 - record.t1) / 3600
+            if duration < 0:
+                continue  # Skip invalid records
+                
+            # Extract tags (words starting with #)
+            tags = [word for word in record.ds.split() if word.startswith("#")]
+
+            if not tags:
+                # If no tags, count as "untagged"
+                tag_key = "untagged"
+                tag_hours[tag_key] = tag_hours.get(tag_key, 0) + duration
+            else:
+                # Add duration to each tag
+                for tag_key in tags:
+                    tag_hours[tag_key] = tag_hours.get(tag_key, 0) + duration
+
+        return {"type": "summary", "data": tag_hours}
+        
+    elif analysis_type == "daily":
+        # Group records by day
+        daily_hours = {}
+        
+        for record in records:
+            # Calculate duration in hours
+            duration = (record.t2 - record.t1) / 3600
+            if duration < 0:
+                continue  # Skip invalid records
+                
+            # Get day from timestamp
+            day = datetime.fromtimestamp(record.t1).strftime("%Y-%m-%d")
+            
+            # Add duration to day
+            daily_hours[day] = daily_hours.get(day, 0) + duration
+            
+        return {"type": "daily", "data": daily_hours}
+        
+    elif analysis_type == "hourly":
+        # Group records by hour of day
+        hourly_distribution = {str(h): 0 for h in range(24)}
+        
+        for record in records:
+            # Calculate duration in hours
+            duration = (record.t2 - record.t1) / 3600
+            if duration < 0:
+                continue  # Skip invalid records
+                
+            # Get start and end hour
+            start_hour = datetime.fromtimestamp(record.t1).hour
+            end_hour = datetime.fromtimestamp(record.t2).hour
+            
+            # If record spans multiple hours, distribute proportionally
+            if start_hour == end_hour:
+                hourly_distribution[str(start_hour)] += duration
+            else:
+                # Simple distribution - just count start hour
+                hourly_distribution[str(start_hour)] += duration
+                
+        return {"type": "hourly", "data": hourly_distribution}
+        
+    else:
+        raise ValueError(f"Invalid analysis type: {analysis_type}")
 
 
 def main():


### PR DESCRIPTION
# Consolidate tools to reduce redundancy

This PR consolidates the tools in the timetagger-mcp project to reduce redundancy.

## Changes:

1. Reduced the number of tools from 14 to 6:
   - Combined record retrieval tools into a single flexible `get_records` function
   - Unified record manipulation into a single `manage_record` function with different actions
   - Consolidated settings management into a single `manage_settings` function
   - Enhanced time analysis with a more powerful `analyze_time` function

2. Added more functionality:
   - More flexible time period options (today, yesterday, week, month, custom hours)
   - Additional analysis views (daily breakdown, hourly distribution)
   - Improved tag filtering

3. Updated documentation to reflect the changes

This consolidation makes the API more consistent and easier to use while maintaining all the original functionality.

**Note:** This PR is in draft status while awaiting review.